### PR TITLE
Catch linting errors in Travis

### DIFF
--- a/src/util/Metamask.ts
+++ b/src/util/Metamask.ts
@@ -14,7 +14,7 @@ export async function enable(): Promise<string|Error> {
   return result
 }
 
-// TODO why can't I import the Transaction from `@computable/.../@types`? 
-export async function send(tx:Transaction): Promise<RpcResponse> {
+// TODO why can't I import the Transaction from `@computable/.../@types`?
+export async function send(tx: Transaction): Promise<RpcResponse> {
   return ethereum.send(tx)
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-  "defaultSeverity": "warning",
+  "defaultSeverity": "error",
   "extends": [
     "tslint:recommended"
   ],


### PR DESCRIPTION
After some digging, was able to enforce linting in Travis by changing the `"defaultSeverity"` setting in the `tslint.json` from `"warning"` to `"error"`. 