### PR TITLE
Move 'Start Listing' button to Drawer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
     <div class="view">
       <router-view/>
     </div>
-    <drawer :isOpen="true">
+    <drawer :isOpen="false">
       <router-view name="drawer" />
     </drawer>
   </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
     <div class="view">
       <router-view/>
     </div>
-    <drawer :isOpen="false">
+    <drawer :isOpen="true">
       <router-view name="drawer" />
     </drawer>
   </div>

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@
     <div class="view">
       <router-view/>
     </div>
-    <drawer v-bind:isOpen="false">
+    <drawer :isOpen="true">
       <router-view name="drawer" />
     </drawer>
   </div>

--- a/src/assets/style/components/list-drawer.sass
+++ b/src/assets/style/components/list-drawer.sass
@@ -1,0 +1,4 @@
+.list-drawer-container
+  width: 100%
+  .list-drawer
+    padding: 24px 0px

--- a/src/assets/style/components/start-listing-button.sass
+++ b/src/assets/style/components/start-listing-button.sass
@@ -3,6 +3,7 @@
   justify-content: center
   align-items: center
   width: 50%
+  height: 100%
 
 .listing-button
   font-size: 14px

--- a/src/assets/style/components/start-listing-button.sass
+++ b/src/assets/style/components/start-listing-button.sass
@@ -1,6 +1,8 @@
 .button-container
   display: flex
   justify-content: center
+  align-items: center
+  width: 50%
 
 .listing-button
   font-size: 14px
@@ -11,6 +13,3 @@
   justify-content: flex-end
   background-color: #eee
   border: none
-
-.listing-button:hover
-  background-color: #ddd

--- a/src/components/listing/FileMetadata.vue
+++ b/src/components/listing/FileMetadata.vue
@@ -19,7 +19,6 @@
               :placeholder="descriptionPlaceholder"></textarea>
           </div>
         </div>
-        <StartListingButton />
         <ffa-tagger
           :taggerKey="taggerKey"/>
       </form>
@@ -47,7 +46,6 @@ import '@/assets/style/components/file-metadata.sass'
 
 @Component({
   components: {
-    StartListingButton,
     TextField,
     FfaTagger,
   },

--- a/src/components/listing/StartListingButton.vue
+++ b/src/components/listing/StartListingButton.vue
@@ -5,21 +5,19 @@
 </template>
 
 <script lang="ts">
-  import Vue from 'vue'
-  import FlashesModule from '../../modules/FlashesModule'
-  import { getModule } from 'vuex-module-decorators'
-  import Flash from '../../models/Flash'
-  import { FlashType } from '../../models/Flash'
-  import '@/assets/style/components/start-listing-button.sass'
-  import { Labels } from '../../util/Constants'
+import { Vue } from 'vue-property-decorator'
+import FlashesModule from '../../modules/FlashesModule'
+import { getModule } from 'vuex-module-decorators'
+import Flash from '../../models/Flash'
+import { FlashType } from '../../models/Flash'
+import '@/assets/style/components/start-listing-button.sass'
+import { Labels } from '../../util/Constants'
 
-  export default Vue.extend({
-    methods: {
-      startListing() {
-        const flashesModule = getModule(FlashesModule, this.$store)
-        const flash = new Flash(Labels.START_LISTING, FlashType.info)
-        flashesModule.append(flash)
-      },
-    },
-  })
+export default class StartListingButton extends Vue {
+    public startListing() {
+      const flashesModule = getModule(FlashesModule, this.$store)
+      const flash = new Flash(Labels.START_LISTING, FlashType.info)
+      flashesModule.append(flash)
+    }
+  }
 </script>

--- a/src/components/listing/StartListingButton.vue
+++ b/src/components/listing/StartListingButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="button-container">
-    <button class="listing-button" @click.prevent="startListing">Start Listing</button>
+    <button class="button" @click.prevent="startListing">Start Listing</button>
   </div>
 </template>
 

--- a/src/components/listing/StartListingButton.vue
+++ b/src/components/listing/StartListingButton.vue
@@ -6,20 +6,13 @@
 
 <script lang="ts">
 import { Vue } from 'vue-property-decorator'
-import FlashesModule from '../../modules/FlashesModule'
 import ListModule from '../../modules/ListModule'
 import { getModule } from 'vuex-module-decorators'
-import Flash from '../../models/Flash'
-import { FlashType } from '../../models/Flash'
 import '@/assets/style/components/start-listing-button.sass'
-import { Labels } from '../../util/Constants'
 
 export default class StartListingButton extends Vue {
     public startListing() {
-      const flashesModule = getModule(FlashesModule, this.$store)
       const listModule = getModule(ListModule, this.$store)
-      const flash = new Flash(Labels.START_LISTING, FlashType.info)
-      flashesModule.append(flash)
       listModule.setListingProcessing(true)
     }
   }

--- a/src/components/listing/StartListingButton.vue
+++ b/src/components/listing/StartListingButton.vue
@@ -7,6 +7,7 @@
 <script lang="ts">
 import { Vue } from 'vue-property-decorator'
 import FlashesModule from '../../modules/FlashesModule'
+import ListModule from '../../modules/ListModule'
 import { getModule } from 'vuex-module-decorators'
 import Flash from '../../models/Flash'
 import { FlashType } from '../../models/Flash'
@@ -16,8 +17,10 @@ import { Labels } from '../../util/Constants'
 export default class StartListingButton extends Vue {
     public startListing() {
       const flashesModule = getModule(FlashesModule, this.$store)
+      const listModule = getModule(ListModule, this.$store)
       const flash = new Flash(Labels.START_LISTING, FlashType.info)
       flashesModule.append(flash)
+      listModule.setListingProcessing(true)
     }
   }
 </script>

--- a/src/components/ui/Drawer.vue
+++ b/src/components/ui/Drawer.vue
@@ -1,7 +1,7 @@
 <template>
   <section
     class="drawer"
-    v-bind:class="openClass"
+    :class="openClass"
     @close-drawer="closeDrawer"
     @open-drawer="openDrawer">
     <slot/>

--- a/src/components/ui/Drawer.vue
+++ b/src/components/ui/Drawer.vue
@@ -4,7 +4,7 @@
     :class="openClass"
     @close-drawer="closeDrawer"
     @open-drawer="openDrawer">
-    <slot/>
+    <slot />
   </section>
 </template>
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,30 +1,30 @@
 import { Nos } from '@computable/computablejs/dist/@types'
 
 declare interface Transaction {
-  to?: string
-  from?: string
-  gas?: Nos
-  gasPrice?: Nos
-  nonce?: Nos
-  data?: string
-  value?: Nos
+  to?: string;
+  from?: string;
+  gas?: Nos;
+  gasPrice?: Nos;
+  nonce?: Nos;
+  data?: string;
+  value?: Nos;
 }
 
 declare interface RpcResponse {
-  jsonrpc: string
-  error: any
-  result: any
-  id: any
+  jsonrpc: string;
+  error: any;
+  result: any;
+  id: any;
 }
 
 declare global {
   namespace ethereum {
-    const isMetaMask: boolean
-    let selectedAddress: string
-    let networkVersion: string
+    const isMetaMask: boolean;
+    let selectedAddress: string;
+    let networkVersion: string;
 
-    function enable(): Promise<string[]>
+    function enable(): Promise<string[]>;
     // TODO make it possible to import Transaction from comp.js/...
-    function send(opts: Transaction): Promise<RpcResponse>
+    function send(opts:Transaction): Promise<RpcResponse>;
   }
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,30 +1,30 @@
 import { Nos } from '@computable/computablejs/dist/@types'
 
 declare interface Transaction {
-  to?: string;
-  from?: string;
-  gas?: Nos;
-  gasPrice?: Nos;
-  nonce?: Nos;
-  data?: string;
-  value?: Nos;
+  to?: string
+  from?: string
+  gas?: Nos
+  gasPrice?: Nos
+  nonce?: Nos
+  data?: string
+  value?: Nos
 }
 
 declare interface RpcResponse {
-  jsonrpc: string;
-  error: any;
-  result: any;
-  id: any;
+  jsonrpc: string
+  error: any
+  result: any
+  id: any
 }
 
 declare global {
   namespace ethereum {
-    const isMetaMask: boolean;
-    let selectedAddress: string;
-    let networkVersion: string;
+    const isMetaMask: boolean
+    let selectedAddress: string
+    let networkVersion: string
 
-    function enable(): Promise<string[]>;
+    function enable(): Promise<string[]>
     // TODO make it possible to import Transaction from comp.js/...
-    function send(opts:Transaction): Promise<RpcResponse>;
+    function send(opts: Transaction): Promise<RpcResponse>
   }
 }

--- a/src/modules/ListModule.ts
+++ b/src/modules/ListModule.ts
@@ -19,6 +19,12 @@ export default class ListModule extends VuexModule implements FfaProcessModule {
     tags: [],
   }
   public percentComplete = 0
+  public listingProcessing = false
+  // @MutationAction({mutate: ['flashes']})
+  // public async fetchAll() {
+  //   const response = [{}] // : Response = await getJSON('https://hasgeek.github.io/events/api/events.json')
+  //   return response
+  // }
 
   @Mutation
   public reset() {
@@ -39,6 +45,21 @@ export default class ListModule extends VuexModule implements FfaProcessModule {
   public setStatus(status: ProcessStatus) {
     this.status = status
   }
+
+  @Mutation
+  public setListingProcessing(listingProcessing: boolean) {
+    this.listingProcessing = listingProcessing
+  }
+
+  // @Mutation
+  // public nextStatus() {
+  //   if (this.status === ProcessStatus.Error) {
+  //     return
+  //   }
+  //   const currentStatusIndex = Number(this.status)
+  //   const nextStatus = ProcessStatus[currentStatusIndex + 1] as keyof typeof ProcessStatus
+  //   this.status = ProcessStatus[nextStatus]
+  // }
 
   get namespace(): string {
     return 'listModule'

--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -44,7 +44,6 @@ import '@/assets/style/views/list.sass'
     FileUploader,
     FileLister,
     FileMetadata,
-    StartListingButton,
   },
 })
 export default class List extends Vue {

--- a/src/views/ListDrawer.vue
+++ b/src/views/ListDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="list-drawer tile is-vertical is-ancestor">
+  <div class="list-drawer tile is-vertical is-ancestor" v-if="isListingProcessing">
       <status
         :vuexModule="uploadModule"
         :statusLabels="uploadLabels"/>
@@ -10,6 +10,7 @@
         :vuexModule="voteModule"
         :statusLabels="voteLabels"/>
   </div>
+  <StartListingButton v-else/>
 </template>
 
 <script lang="ts">
@@ -27,6 +28,7 @@ import { Messages, Errors } from '../util/Constants'
 @Component({
   components: {
     Status,
+    StartListingButton,
   },
 })
 export default class ListDrawer extends Vue {
@@ -60,6 +62,10 @@ export default class ListDrawer extends Vue {
     this.voteLabels[ProcessStatus.Executing] = Messages.VOTING
     this.voteLabels[ProcessStatus.Complete] = Messages.VOTED
     this.voteLabels[ProcessStatus.Error] = Errors.VOTING_FAILED
+  }
+
+  get isListingProcessing() {
+    return this.listModule.listingProcessing
   }
 }
 </script>

--- a/src/views/ListDrawer.vue
+++ b/src/views/ListDrawer.vue
@@ -1,16 +1,19 @@
 <template>
-  <div class="list-drawer tile is-vertical is-ancestor" v-if="isListingProcessing">
+<div class="list-drawer-container">
+    <div id="list-drawer" class="list-drawer tile is-vertical is-ancestor list-drawer" v-show="isListingProcessing"> 
+
       <status
-        :vuexModule="uploadModule"
-        :statusLabels="uploadLabels"/>
-      <status
-        :vuexModule="listModule"
-        :statusLabels="listLabels"/>
-      <status
-        :vuexModule="voteModule"
-        :statusLabels="voteLabels"/>
-  </div>
-  <StartListingButton v-else/>
+          :vuexModule="uploadModule"
+          :statusLabels="uploadLabels"/>
+        <status
+          :vuexModule="listModule"
+          :statusLabels="listLabels"/>
+        <status
+          :vuexModule="voteModule"
+          :statusLabels="voteLabels"/>
+    </div>
+    <StartListingButton v-show="!isListingProcessing"/>
+</div>
 </template>
 
 <script lang="ts">
@@ -24,6 +27,7 @@ import StartListingButton from '../components/datatrust/StartListingButton.vue'
 import { ProcessStatus, ProcessStatusLabelMap } from '../models/ProcessStatus'
 import FfaProcessModule from '../interfaces/vuex/FfaProcessModule'
 import { Messages, Errors } from '../util/Constants'
+import '@/assets/style/components/list-drawer.sass'
 
 @Component({
   components: {

--- a/src/views/ListDrawer.vue
+++ b/src/views/ListDrawer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="list-drawer-container">
-      <div id="list-drawer" class="list-drawer tile is-vertical is-ancestor list-drawer" v-show="isListingProcessing"> 
+      <div id="list-drawer" class="list-drawer tile is-vertical is-ancestor list-drawer" v-show="isListingProcessing">
         <status
             :vuexModule="uploadModule"
             :statusLabels="uploadLabels"/>
@@ -22,7 +22,7 @@ import UploadModule from '../modules/UploadModule'
 import ListModule from '../modules/ListModule'
 import VoteModule from '../modules/VoteModule'
 import Status from '@/components/ui/Status.vue'
-import StartListingButton from '../components/datatrust/StartListingButton.vue'
+import StartListingButton from '../components/listing/StartListingButton.vue'
 import { ProcessStatus, ProcessStatusLabelMap } from '../models/ProcessStatus'
 import FfaProcessModule from '../interfaces/vuex/FfaProcessModule'
 import { Messages, Errors } from '../util/Constants'

--- a/src/views/ListDrawer.vue
+++ b/src/views/ListDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="list-drawer tile is-vertical is-ancestor" v-if="isProcessing">
+  <div class="list-drawer tile is-vertical is-ancestor">
       <status
         :vuexModule="uploadModule"
         :statusLabels="uploadLabels"/>
@@ -10,9 +10,6 @@
         :vuexModule="voteModule"
         :statusLabels="voteLabels"/>
   </div>
-  <div v-else>
-    <StartListingButton />
-  </div>
 </template>
 
 <script lang="ts">
@@ -22,20 +19,17 @@ import UploadModule from '../modules/UploadModule'
 import ListModule from '../modules/ListModule'
 import VoteModule from '../modules/VoteModule'
 import Status from '@/components/ui/Status.vue'
+import StartListingButton from '../components/datatrust/StartListingButton.vue'
 import { ProcessStatus, ProcessStatusLabelMap } from '../models/ProcessStatus'
 import FfaProcessModule from '../interfaces/vuex/FfaProcessModule'
 import { Messages, Errors } from '../util/Constants'
-import StartListingButton from '../components/datatrust/StartListingButton.vue'
 
 @Component({
   components: {
     Status,
-    StartListingButton,
   },
 })
 export default class ListDrawer extends Vue {
-
-  public isProcessing: boolean = false
 
   private uploadLabels!: ProcessStatusLabelMap
   private listLabels!: ProcessStatusLabelMap

--- a/src/views/ListDrawer.vue
+++ b/src/views/ListDrawer.vue
@@ -1,7 +1,6 @@
 <template>
 <div class="list-drawer-container">
     <div id="list-drawer" class="list-drawer tile is-vertical is-ancestor list-drawer" v-show="isListingProcessing"> 
-
       <status
           :vuexModule="uploadModule"
           :statusLabels="uploadLabels"/>

--- a/src/views/ListDrawer.vue
+++ b/src/views/ListDrawer.vue
@@ -1,18 +1,18 @@
 <template>
-<div class="list-drawer-container">
-    <div id="list-drawer" class="list-drawer tile is-vertical is-ancestor list-drawer" v-show="isListingProcessing"> 
-      <status
-          :vuexModule="uploadModule"
-          :statusLabels="uploadLabels"/>
+  <div class="list-drawer-container">
+      <div id="list-drawer" class="list-drawer tile is-vertical is-ancestor list-drawer" v-show="isListingProcessing"> 
         <status
-          :vuexModule="listModule"
-          :statusLabels="listLabels"/>
-        <status
-          :vuexModule="voteModule"
-          :statusLabels="voteLabels"/>
-    </div>
-    <StartListingButton v-show="!isListingProcessing"/>
-</div>
+            :vuexModule="uploadModule"
+            :statusLabels="uploadLabels"/>
+          <status
+            :vuexModule="listModule"
+            :statusLabels="listLabels"/>
+          <status
+            :vuexModule="voteModule"
+            :statusLabels="voteLabels"/>
+      </div>
+      <StartListingButton v-show="!isListingProcessing"/>
+  </div>
 </template>
 
 <script lang="ts">
@@ -67,7 +67,7 @@ export default class ListDrawer extends Vue {
     this.voteLabels[ProcessStatus.Error] = Errors.VOTING_FAILED
   }
 
-  get isListingProcessing() {
+  get isListingProcessing(): boolean {
     return this.listModule.listingProcessing
   }
 }

--- a/src/views/ListDrawer.vue
+++ b/src/views/ListDrawer.vue
@@ -1,19 +1,22 @@
 <template>
-  <div class="list-drawer tile is-vertical is-ancestor">
-    <status
-      :vuexModule="uploadModule"
-      :statusLabels="uploadLabels"/>
-    <status
-      :vuexModule="listModule"
-      :statusLabels="listLabels"/>
-    <status
-      :vuexModule="voteModule"
-      :statusLabels="voteLabels"/>
+  <div class="list-drawer tile is-vertical is-ancestor" v-if="isProcessing">
+      <status
+        :vuexModule="uploadModule"
+        :statusLabels="uploadLabels"/>
+      <status
+        :vuexModule="listModule"
+        :statusLabels="listLabels"/>
+      <status
+        :vuexModule="voteModule"
+        :statusLabels="voteLabels"/>
+  </div>
+  <div v-else>
+    <StartListingButton />
   </div>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator'
+import { Component, Vue, Prop } from 'vue-property-decorator'
 import { getModule } from 'vuex-module-decorators'
 import UploadModule from '../modules/UploadModule'
 import ListModule from '../modules/ListModule'
@@ -22,13 +25,17 @@ import Status from '@/components/ui/Status.vue'
 import { ProcessStatus, ProcessStatusLabelMap } from '../models/ProcessStatus'
 import FfaProcessModule from '../interfaces/vuex/FfaProcessModule'
 import { Messages, Errors } from '../util/Constants'
+import StartListingButton from '../components/datatrust/StartListingButton.vue'
 
 @Component({
   components: {
     Status,
+    StartListingButton,
   },
 })
 export default class ListDrawer extends Vue {
+
+  public isProcessing: boolean = false
 
   private uploadLabels!: ProcessStatusLabelMap
   private listLabels!: ProcessStatusLabelMap

--- a/tests/unit/components/datatrust/StartListingButton.spec.ts
+++ b/tests/unit/components/datatrust/StartListingButton.spec.ts
@@ -4,7 +4,6 @@ import StartListingButton from '../../../../src/components/listing/StartListingB
 import appStore from '../../../../src/store'
 
 const localVue = createLocalVue()
-const startListingButtonClass = 'listing-button'
 
 describe('StartListingButton.vue', () => {
   beforeAll(() => {
@@ -18,6 +17,5 @@ describe('StartListingButton.vue', () => {
       localVue,
     })
     expect(wrapper.findAll('button').length).toBe(1)
-    expect(wrapper.findAll(`button.${startListingButtonClass}`).length).toBe(1)
   })
 })

--- a/tests/unit/components/datatrust/StartListingButton.spec.ts
+++ b/tests/unit/components/datatrust/StartListingButton.spec.ts
@@ -4,8 +4,10 @@ import StartListingButton from '../../../../src/components/listing/StartListingB
 import appStore from '../../../../src/store'
 
 const localVue = createLocalVue()
+const buttonClass = 'button'
 
 describe('StartListingButton.vue', () => {
+
   beforeAll(() => {
     localVue.use(VueRouter)
   })
@@ -16,6 +18,6 @@ describe('StartListingButton.vue', () => {
       store: appStore,
       localVue,
     })
-    expect(wrapper.findAll('button').length).toBe(1)
+    expect(wrapper.findAll(`.${buttonClass}`).length).toBe(1)
   })
 })

--- a/tests/unit/components/ui/Drawer.spec.ts
+++ b/tests/unit/components/ui/Drawer.spec.ts
@@ -1,4 +1,4 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils'
+import { shallowMount, createLocalVue, mount } from '@vue/test-utils'
 import VueRouter from 'vue-router'
 import Drawer from '@/components/ui/Drawer.vue'
 import appStore from '../../../../src/store'
@@ -9,6 +9,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import FileUploader from '@/components/listing/FileUploader.vue'
 
 const localVue = createLocalVue()
+localVue.use(VueRouter)
 library.add(faFileSolid, faFile, faCheckCircle)
 const drawerClass = 'drawer'
 
@@ -25,7 +26,7 @@ describe('Drawer.vue', () => {
       attachToDocument: true,
       store: appStore,
       localVue,
-    })
+  })
     expect(wrapper.findAll(`section.${drawerClass}`).length).toBe(1)
   })
 })

--- a/tests/unit/views/ListDrawer.spec.ts
+++ b/tests/unit/views/ListDrawer.spec.ts
@@ -12,6 +12,7 @@ const localVue = createLocalVue()
 library.add(faFileSolid, faFile, faCheckCircle)
 const listDrawerClass = 'list-drawer'
 const statusClass = 'status'
+const buttonClass = 'button'
 
 describe('ListDrawer.vue', () => {
 
@@ -29,5 +30,15 @@ describe('ListDrawer.vue', () => {
     })
     expect(wrapper.findAll(`.${listDrawerClass}`).length).toBe(1)
     expect(wrapper.findAll(`.${statusClass}`).length).toBe(3)
+  })
+
+  it('renders the Start Listing Button', () => {
+    const wrapper = mount(ListDrawer, {
+      attachToDocument: true,
+      store: appStore,
+      localVue,
+    })
+    expect(wrapper.findAll(`.${buttonClass}`).length).toBe(1)
+
   })
 })

--- a/tests/unit/views/ListDrawer.spec.ts
+++ b/tests/unit/views/ListDrawer.spec.ts
@@ -39,6 +39,16 @@ describe('ListDrawer.vue', () => {
       localVue,
     })
     expect(wrapper.findAll(`.${buttonClass}`).length).toBe(1)
+  })
 
+  it('displays the upload button on Start Listing Button click', () => {
+    const wrapper = mount(ListDrawer, {
+      attachToDocument: true,
+      store: appStore,
+      localVue,
+    })
+    const buttonWrapper = wrapper.find(`${buttonClass}`)
+    buttonWrapper.trigger('click')
+    expect(wrapper.find(`.${listDrawerClass}`).isVisible()).toBe(true)
   })
 })


### PR DESCRIPTION
According to the [Figma](https://www.figma.com/file/AglzT0bAqBNG2iJIApeZ6d/FFA-new-listing%2C-buy-listing?node-id=0%3A1) the file is dropped into the uploader, and the drawer opens up to enable listing submission. Clicking the `Submit Listing` button changes the drawer to the 'processing' state and automatically uploads the file. 

Within this PR, to upload, the `Start Listing` button must first be clicked, then file should be dropped, then the `upload` button clicked. 

I've temporarily changed the default for the drawer to be open within this PR because dropping a file then clicking `Start Listing` doesn't allow you to upload. 

I think ultimately, the `Start Listing` button should have the functionality that the `upload` button currently has. I can work on this on this same PR & ticket, or I can create a new ticket if that's better- let me know what you think. 