### PR TITLE
Implement MetaMask send and FFA List

### DIFF
--- a/src/functionModules/components/FileUploaderModule.ts
+++ b/src/functionModules/components/FileUploaderModule.ts
@@ -14,7 +14,7 @@ const hashParam = 'listing_hash'
 
 export default class FileUploaderModule {
   public static preprocessFileData(formData: FormData, uploadModule: UploadModule)  {
-    formData.append(originalFilenameParam, uploadModule.originalFilename)
+    // formData.append(originalFilenameParam, uploadModule.originalFilename)
     formData.append(titleParam, uploadModule.title)
     formData.append(descriptionParam, uploadModule.description)
     formData.append(filenamesParam, uploadModule.file.name)
@@ -22,6 +22,7 @@ export default class FileUploaderModule {
     formData.append(md5SumParam, uploadModule.md5)
     formData.append(tagsParam, uploadModule.tags.join())
     formData.append(hashParam, uploadModule.hash)
+    formData.append('license', 'MIT')
   }
 
   public static renameFile(filename: string, newFilename: string, uploadModule: UploadModule) {

--- a/src/functionModules/protocol/ListingModule.ts
+++ b/src/functionModules/protocol/ListingModule.ts
@@ -5,6 +5,14 @@ import { buildTransaction } from '@computable/computablejs/dist/helpers'
 import ListingContract from '@computable/computablejs/dist/contracts/listing'
 import { TransactOpts } from '@computable/computablejs/dist/interfaces'
 
+import { getModule } from 'vuex-module-decorators'
+import FlashesModule from '../../modules/FlashesModule'
+import store from '../../store'
+import Flash from '../../models/Flash'
+import { FlashType } from '../../models/Flash'
+
+import { send } from '../../util/Metamask'
+
 import Web3 from 'web3'
 
 export default class ListingModule {
@@ -18,11 +26,14 @@ export default class ListingModule {
     return listing
   }
 
-  // TODO: actual metamask/ethereum send() implemention and transaction hash return
   public static async list(account: string, web3: Web3, listingHash: string, transactOpts: TransactOpts) {
+    const flashesModule = getModule(FlashesModule, store)
+    flashesModule.append(new Flash(`listingHash: ${listingHash}`, FlashType.info))
     const listing = await ListingModule.getListing(account, web3)
     const method =  await listing.list(listingHash, transactOpts)
     const unsigned = await buildTransaction(web3, method)
-    await ethereum.send(unsigned)
+    unsigned.to = ContractAddresses.ListingAddress
+    unsigned.value = '0x0'
+    send(web3, unsigned, flashesModule)
   }
 }

--- a/src/functionModules/protocol/ListingModule.ts
+++ b/src/functionModules/protocol/ListingModule.ts
@@ -40,7 +40,9 @@ export default class ListingModule {
     // MM ignores any nonce, let's just remove it
     delete unsigned.nonce
     // take the larger of the two gas estimates to be safe
-    if (est > unsigned.gas) unsigned.gas = est
+    if (est > unsigned.gas) {
+      unsigned.gas = est
+    }
     send(web3, unsigned, flashesModule)
   }
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,4 +1,5 @@
 import { Nos } from '@computable/computablejs/dist/@types'
+import Web3 from 'web3'
 
 declare interface Transaction {
   to?: string;
@@ -8,6 +9,12 @@ declare interface Transaction {
   nonce?: Nos;
   data?: string;
   value?: Nos;
+}
+
+declare interface RpcRequest {
+  method: string
+  params: any[]
+  from: string
 }
 
 declare interface RpcResponse {
@@ -26,5 +33,6 @@ declare global {
     function enable(): Promise<string[]>;
     // TODO make it possible to import Transaction from comp.js/...
     function send(opts:Transaction): Promise<RpcResponse>;
+    function sendAsync(request: RpcRequest, callback: (err: any, res: any)=>void): void;
   }
 }

--- a/src/util/Constants.ts
+++ b/src/util/Constants.ts
@@ -49,3 +49,6 @@ export const Placeholders = {
 export const Keys = {
   FILE_METADATA_KEY: 'FileMetadata',
 }
+
+// common to use this for value: in transact opts
+export const ZERO_HASHED = '0x0'

--- a/src/util/Metamask.ts
+++ b/src/util/Metamask.ts
@@ -19,7 +19,6 @@ export async function enable(): Promise<string|Error> {
 }
 
 export async function send(web3: Web3, opts: Transaction, flashesModule: FlashesModule) {
-
   opts.gas = web3.utils.toHex(opts.gas)
   opts.gasPrice = web3.utils.toHex(opts.gasPrice)
   // debugger
@@ -31,7 +30,7 @@ export async function send(web3: Web3, opts: Transaction, flashesModule: Flashes
     if (err) {
       // TODO: complain
     } else {
-      flashesModule.append(new Flash(res.result, FlashType.info))
+      flashesModule.append(new Flash(`Transaction hash: ${res.result}`, FlashType.info))
     }
   })
 }

--- a/src/util/Metamask.ts
+++ b/src/util/Metamask.ts
@@ -1,5 +1,9 @@
 // import { Errors } from './Constants'
 import { Transaction, RpcResponse } from '../global'
+import Web3 from 'web3'
+import FlashesModule from '../modules/FlashesModule'
+import Flash from '../models/Flash'
+import { FlashType } from '../models/Flash'
 
 export async function enable(): Promise<string|Error> {
   let result: string
@@ -14,7 +18,20 @@ export async function enable(): Promise<string|Error> {
   return result
 }
 
-// TODO why can't I import the Transaction from `@computable/.../@types`?
-export async function send(tx: Transaction): Promise<RpcResponse> {
-  return ethereum.send(tx)
+export async function send(web3: Web3, opts: Transaction, flashesModule: FlashesModule) {
+
+  opts.gas = web3.utils.toHex(opts.gas)
+  opts.gasPrice = web3.utils.toHex(opts.gasPrice)
+  // debugger
+  ethereum.sendAsync({
+    method: 'eth_sendTransaction',
+    params: [opts], // NOTE: do not miss that this is an array of 1
+    from: ethereum.selectedAddress,
+  }, (err: any, res: any) => {
+    if (err) {
+      // TODO: complain
+    } else {
+      flashesModule.append(new Flash(res.result, FlashType.info))
+    }
+  })
 }

--- a/tests/unit/functionModules/components/FileUploaderModule.spec.ts
+++ b/tests/unit/functionModules/components/FileUploaderModule.spec.ts
@@ -51,7 +51,7 @@ describe('FileUploaderModule.ts', () => {
 
 
       expect(newForm.get('title')).toEqual(titleParam)
-      expect(newForm.get('originalFilename')).toEqual(originalFilenameParam)
+      // expect(newForm.get('originalFilename')).toEqual(originalFilenameParam)
       expect(newForm.get('description')).toEqual(descriptionParam)
       expect(newForm.get('md5_sum')).toEqual(md5SumParam)
       expect(newForm.get('tags')).toEqual(tagsParam)


### PR DESCRIPTION
Added in a call to `estimateGas` to circumvent times where the gas estimate was too small. I actually like this in the app as:
1. That's where estimating gas belongs, as the lib does not know where it connects to
2. There is the extra safety of the ABI generated estimates in case estimateGas falls on its face.

I'm sure they'll be cases where things fail due to gas still, but that's just the nature of the beast. 

@ReidWilliams 
NOTE: We may want to provide an `advanced` UI section for power users who want to intentionally inflate gas/gasPrice as this is a thing -- it can _possibly_ get your TX done faster.