### PR TITLE
Listings test

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "serve": "export NODE_OPTIONS=\"--max-old-space-size=4096\"; vue-cli-service serve",
-    "build": "export NODE_OPTIONS=\"--max-old-space-size=4096\"; vue-cli-service build",
+    "serve": "vue-cli-service serve",
+    "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
-    "test:unit": "export NODE_OPTIONS=\"--max-old-space-size=4096\"; vue-cli-service lint; vue-cli-service test:unit --coverage"
+    "test:unit": "vue-cli-service lint; vue-cli-service test:unit --coverage"
   },
   "engines": {
     "node": ">=10.16.0"

--- a/src/components/ui/FfaListingComponent.vue
+++ b/src/components/ui/FfaListingComponent.vue
@@ -59,26 +59,34 @@ export default class FfaListingComponent extends Vue {
     const addressProvided = !!this.userAddress
     const statusNotProvided = !!!this.status
 
-    // Show User listings only
-    if (addressProvided) {
-      if (statusNotProvided) {
-        await this.displayUserAllListings()
-      } else if (this.status === FfaListingStatus.candidate) {
-        await this.displayUserCandidates()
-      } else if (this.status === FfaListingStatus.listed) {
-      // } else {
-        await this.displayUserListed()
-      }
-      return
-    }
-    // Show all listings
     if (statusNotProvided) {
-      await this.displayAllListings()
-    } else if (this.status === FfaListingStatus.candidate) {
-      await this.displayAllCandidates()
-    } else if (this.status === FfaListingStatus.listed) {
-    // } else {
-      await this.displayAllListed()
+      addressProvided ? await this.displayUserAllListings() : await this.displayAllListings()
+    } else {
+      addressProvided ? await this.renderFilteredUserList() : await this.renderFilteredAllList()
+    }
+  }
+
+  private async renderFilteredUserList() {
+    switch (this.status) {
+      case FfaListingStatus.candidate:
+        await this.displayUserCandidates()
+        return
+      case FfaListingStatus.listed:
+        await this.displayUserListed()
+        return
+      default:
+    }
+  }
+
+  private async renderFilteredAllList() {
+    switch (this.status) {
+      case FfaListingStatus.candidate:
+        await this.displayAllCandidates()
+        return
+      case FfaListingStatus.listed:
+        await this.displayAllListed()
+        return
+      default:
     }
   }
 

--- a/src/components/ui/FfaListingComponent.vue
+++ b/src/components/ui/FfaListingComponent.vue
@@ -38,7 +38,7 @@ export default class FfaListingComponent extends Vue {
   @Prop()
   public status?: FfaListingStatus
 
-  private async mounted() {
+  private mounted() {
     this.$store.subscribe(this.vuexSubscriptions)
     this.renderList()
   }
@@ -114,7 +114,7 @@ export default class FfaListingComponent extends Vue {
     this.displayedListings = this.ffaListingsModule.listed
   }
 
-  private async displayAllListings() {
+  private displayAllListings() {
     this.displayedListings = this.ffaListingsModule.allListings
   }
 }

--- a/src/components/ui/FfaListingComponent.vue
+++ b/src/components/ui/FfaListingComponent.vue
@@ -20,6 +20,8 @@ import FfaListing from '../../models/FfaListing'
 import '@/assets/style/components/listing.sass'
 import { FfaListingStatus } from '../../models/FfaListing'
 
+// TODO
+const vuexModuleName = 'uploadModule'
 @Component({
   components: {
     FfaListingItem,
@@ -36,15 +38,19 @@ export default class FfaListingComponent extends Vue {
   @Prop()
   public status?: FfaListingStatus
 
-  private mounted() {
+  private async mounted() {
     this.$store.subscribe(this.vuexSubscriptions)
     this.renderList()
   }
 
-  private vuexSubscriptions(mutation: MutationPayload, state: any) {
+  private async vuexSubscriptions(mutation: MutationPayload, state: any) {
+    const mutationVuexModule = mutation.type.split('/')[0]
+    if (mutationVuexModule !== vuexModuleName) {
+      return
+    }
     switch (mutation.type) {
       default:
-      this.renderList()
+        await this.renderList()
     }
   }
 

--- a/src/components/ui/FfaListingComponent.vue
+++ b/src/components/ui/FfaListingComponent.vue
@@ -43,99 +43,79 @@ export default class FfaListingComponent extends Vue {
     this.renderList()
   }
 
-  private async vuexSubscriptions(mutation: MutationPayload, state: any) {
-    const mutationVuexModule = mutation.type.split('/')[0]
-    if (mutationVuexModule !== vuexModuleName) {
+  private vuexSubscriptions(mutation: MutationPayload, state: any) {
+    const payloadModule = mutation.type.split('/')[0]
+    if (payloadModule !== vuexModuleName) {
       return
     }
     switch (mutation.type) {
       default:
-        await this.renderList()
+        this.renderList()
     }
   }
 
-  private async renderList() {
+  private renderList() {
     // Check if userAddress is truthy
     const addressProvided = !!this.userAddress
     const statusNotProvided = !!!this.status
 
     if (statusNotProvided) {
-      addressProvided ? await this.displayUserAllListings() : await this.displayAllListings()
+      addressProvided ? this.displayUserAllListings() : this.displayAllListings()
     } else {
-      addressProvided ? await this.renderFilteredUserList() : await this.renderFilteredAllList()
+      addressProvided ? this.renderFilteredUserList() : this.renderFilteredAllList()
     }
   }
 
-  private async renderFilteredUserList() {
+  private renderFilteredUserList() {
     switch (this.status) {
       case FfaListingStatus.candidate:
-        await this.displayUserCandidates()
+        this.displayUserCandidates()
         return
       case FfaListingStatus.listed:
-        await this.displayUserListed()
+        this.displayUserListed()
         return
       default:
     }
   }
 
-  private async renderFilteredAllList() {
+  private renderFilteredAllList() {
     switch (this.status) {
       case FfaListingStatus.candidate:
-        await this.displayAllCandidates()
+        this.displayAllCandidates()
         return
       case FfaListingStatus.listed:
-        await this.displayAllListed()
+        this.displayAllListed()
         return
       default:
     }
-  }
-
-  private async fetchAllCandidates() {
-    await this.ffaListingsModule.fetchCandidates()
-  }
-
-  private async fetchAllListed() {
-    await this.ffaListingsModule.fetchListed()
-  }
-
-  private async fetchAllListings() {
-    await this.ffaListingsModule.fetchCandidates()
-    await this.ffaListingsModule.fetchListed()
   }
 
   private filterUserListing(inputListings: FfaListing[]): FfaListing[] {
     return inputListings.filter((listing) => listing.owner === this.userAddress)
   }
 
-  private async displayUserCandidates() {
-    await this.fetchAllCandidates()
+  private displayUserCandidates() {
     this.displayedListings = this.filterUserListing(this.ffaListingsModule.candidates)
   }
 
-  private async displayUserListed() {
-    await this.fetchAllListed()
+  private displayUserListed() {
     this.displayedListings = this.filterUserListing(this.ffaListingsModule.listed)
   }
 
-  private async displayUserAllListings() {
-    await this.fetchAllListings()
-    const allListings = (this.ffaListingsModule.candidates).concat(this.ffaListingsModule.listed)
-    this.displayedListings = this.filterUserListing(allListings)
+  private displayUserAllListings() {
+    this.displayedListings = this.filterUserListing(this.ffaListingsModule.allListings)
   }
 
-  private async displayAllCandidates() {
-    await this.fetchAllCandidates()
+  private displayAllCandidates() {
     this.displayedListings = this.ffaListingsModule.candidates
   }
 
-  private async displayAllListed() {
-    await this.fetchAllListed()
+  private displayAllListed() {
     this.displayedListings = this.ffaListingsModule.listed
   }
 
   private async displayAllListings() {
-    await this.fetchAllListings()
-    this.displayedListings = (this.ffaListingsModule.candidates).concat(this.ffaListingsModule.listed)
+    this.displayedListings = this.ffaListingsModule.allListings
   }
 }
 </script>

--- a/src/components/ui/FfaListingComponent.vue
+++ b/src/components/ui/FfaListingComponent.vue
@@ -21,7 +21,7 @@ import '@/assets/style/components/listing.sass'
 import { FfaListingStatus } from '../../models/FfaListing'
 
 // TODO
-const vuexModuleName = 'uploadModule'
+const vuexModuleName = 'ffaListingsModule'
 @Component({
   components: {
     FfaListingItem,

--- a/src/components/ui/FfaListingItem.vue
+++ b/src/components/ui/FfaListingItem.vue
@@ -6,7 +6,7 @@
     <span class="column listing-property">{{ listing.hash }}</span>
     <span class="column listing-property">{{ listing.md5 }}</span>
     <span class="column listing-property">{{ listing.tags }}</span>
-    <span class="column listing-property" data-property="status">{{ listing.status }}</span>
+    <span class="column listing-property" :data-status="listing.status">{{ listing.status }}</span>
     <span class="column listing-property" data-property="owner">{{ listing.owner }}</span>
   </div>
 </template>
@@ -19,5 +19,6 @@ import FfaListing from '../../models/FfaListing'
 export default class FfaListingItem extends Vue {
   @Prop()
   public listing!: FfaListing
+
 }
 </script>

--- a/src/components/ui/FfaListingsComponent.vue
+++ b/src/components/ui/FfaListingsComponent.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="columns-container">
-    <FfaListingHeader />
-    <FfaListingItem 
+    <FfaListingsHeader />
+    <FfaListingsItem 
       class="ffa-listing"
       v-for="listing in displayedListings" 
       :listing="listing" 
@@ -11,8 +11,8 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator'
-import FfaListingItem from './FfaListingItem.vue'
-import FfaListingHeader from './FfaListingHeader.vue'
+import FfaListingsItem from './FfaListingsItem.vue'
+import FfaListingsHeader from './FfaListingsHeader.vue'
 import { MutationPayload } from 'vuex'
 import { getModule } from 'vuex-module-decorators'
 import FfaListingsModule from '../../vuexModules/FfaListingsModule'
@@ -20,15 +20,14 @@ import FfaListing from '../../models/FfaListing'
 import '@/assets/style/components/listing.sass'
 import { FfaListingStatus } from '../../models/FfaListing'
 
-// TODO
 const vuexModuleName = 'ffaListingsModule'
 @Component({
   components: {
-    FfaListingItem,
-    FfaListingHeader,
+    FfaListingsItem,
+    FfaListingsHeader,
   },
 })
-export default class FfaListingComponent extends Vue {
+export default class FfaListingsComponent extends Vue {
   public ffaListingsModule: FfaListingsModule = getModule(FfaListingsModule, this.$store)
   public displayedListings: FfaListing[] = []
 
@@ -60,7 +59,7 @@ export default class FfaListingComponent extends Vue {
     const statusNotProvided = !!!this.status
 
     if (statusNotProvided) {
-      addressProvided ? this.displayUserAllListings() : this.displayAllListings()
+      addressProvided ? this.displayAllUserListings() : this.displayAllListings()
     } else {
       addressProvided ? this.renderFilteredUserList() : this.renderFilteredAllList()
     }
@@ -102,7 +101,7 @@ export default class FfaListingComponent extends Vue {
     this.displayedListings = this.filterUserListing(this.ffaListingsModule.listed)
   }
 
-  private displayUserAllListings() {
+  private displayAllUserListings() {
     this.displayedListings = this.filterUserListing(this.ffaListingsModule.allListings)
   }
 

--- a/src/components/ui/FfaListingsHeader.vue
+++ b/src/components/ui/FfaListingsHeader.vue
@@ -16,7 +16,7 @@ import { Component, Vue } from 'vue-property-decorator'
 import '@/assets/style/components/listing.sass'
 
 @Component
-export default class FfaListingHeader extends Vue {
+export default class FfaListingsHeader extends Vue {
 
 }
 </script>

--- a/src/components/ui/FfaListingsItem.vue
+++ b/src/components/ui/FfaListingsItem.vue
@@ -16,7 +16,7 @@ import { Component, Vue, Prop } from 'vue-property-decorator'
 import FfaListing from '../../models/FfaListing'
 
 @Component
-export default class FfaListingItem extends Vue {
+export default class FfaListingsItem extends Vue {
   @Prop()
   public listing!: FfaListing
 

--- a/src/views/Listings.vue
+++ b/src/views/Listings.vue
@@ -1,5 +1,5 @@
 <template>
-  <FfaListingComponent
+  <FfaListingsComponent
     :userAddress="userAddress"
     :status="status"/>
 </template>
@@ -7,12 +7,12 @@
  <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
 import '@/assets/style/components/listing.sass'
-import FfaListingComponent from '../../src/components/ui/FfaListingComponent.vue'
+import FfaListingsComponent from '../../src/components/ui/FfaListingsComponent.vue'
 import FfaListing, { FfaListingStatus } from '../models/FfaListing'
 
 @Component({
   components: {
-    FfaListingComponent,
+    FfaListingsComponent,
   },
 })
  export default class Listings extends Vue {

--- a/src/vuexModules/FfaListingsModule.ts
+++ b/src/vuexModules/FfaListingsModule.ts
@@ -20,6 +20,12 @@ export default class FfaListingsModule extends VuexModule {
     this.purchases = []
  }
 
+ @Mutation
+ public clearAll() {
+   this.candidates = []
+   this.listed = []
+ }
+
   @Mutation
   public setCandidates(candidates: FfaListing[]) {
     this.candidates = candidates
@@ -40,6 +46,8 @@ export default class FfaListingsModule extends VuexModule {
     if (this.listed.filter((l) => l.hash === candidate.hash).length > 0) {
       return
     }
+
+    candidate.status = FfaListingStatus.listed
 
     this.listed.push(candidate)
     this.candidates = this.candidates.filter((f) => f.title !== candidate.title)

--- a/src/vuexModules/FfaListingsModule.ts
+++ b/src/vuexModules/FfaListingsModule.ts
@@ -67,7 +67,7 @@ export default class FfaListingsModule extends VuexModule {
 
   @MutationAction({mutate: ['candidates', 'lastCandidatesBlock']})
   public async fetchCandidates() {
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+    await new Promise((resolve) => setTimeout(resolve, 20))
     // tslint:disable:max-line-length
     const file1 = new FfaListing('title1', 'description1', 'type1', 'hash1', 'md51', [], FfaListingStatus.candidate, '0xwall3t')
     const file2 = new FfaListing('title2', 'description2', 'type2', 'hash2', 'md52', [], FfaListingStatus.candidate, '0xwall3t')
@@ -89,7 +89,7 @@ export default class FfaListingsModule extends VuexModule {
 
   @MutationAction({mutate: ['listed', 'lastListedBlock']})
   public async fetchListed() {
-    await new Promise((resolve) => setTimeout(resolve, 1000))
+    await new Promise((resolve) => setTimeout(resolve, 20))
     // tslint:disable:max-line-length
     const file1 = new FfaListing('title7', 'description6', 'type6', 'hash6', 'md56', [], FfaListingStatus.listed, '0xwall3t')
     const file2 = new FfaListing('title8', 'description7', 'type7', 'hash7', 'md57', [], FfaListingStatus.listed, '0xwall3t')

--- a/src/vuexModules/FfaListingsModule.ts
+++ b/src/vuexModules/FfaListingsModule.ts
@@ -67,7 +67,7 @@ export default class FfaListingsModule extends VuexModule {
 
   @MutationAction({mutate: ['candidates', 'lastCandidatesBlock']})
   public async fetchCandidates() {
-    await new Promise((resolve) => setTimeout(resolve, 2000))
+    await new Promise((resolve) => setTimeout(resolve, 1000))
     // tslint:disable:max-line-length
     const file1 = new FfaListing('title1', 'description1', 'type1', 'hash1', 'md51', [], FfaListingStatus.candidate, '0xwall3t')
     const file2 = new FfaListing('title2', 'description2', 'type2', 'hash2', 'md52', [], FfaListingStatus.candidate, '0xwall3t')
@@ -89,7 +89,7 @@ export default class FfaListingsModule extends VuexModule {
 
   @MutationAction({mutate: ['listed', 'lastListedBlock']})
   public async fetchListed() {
-    await new Promise((resolve) => setTimeout(resolve, 2000))
+    await new Promise((resolve) => setTimeout(resolve, 1000))
     // tslint:disable:max-line-length
     const file1 = new FfaListing('title7', 'description6', 'type6', 'hash6', 'md56', [], FfaListingStatus.listed, '0xwall3t')
     const file2 = new FfaListing('title8', 'description7', 'type7', 'hash7', 'md57', [], FfaListingStatus.listed, '0xwall3t')
@@ -109,7 +109,6 @@ export default class FfaListingsModule extends VuexModule {
     }
     return response
   }
-
 
 
   get namespace(): string {

--- a/src/vuexModules/FfaListingsModule.ts
+++ b/src/vuexModules/FfaListingsModule.ts
@@ -110,7 +110,6 @@ export default class FfaListingsModule extends VuexModule {
     return response
   }
 
-
   get namespace(): string {
     return 'ffaListingsModule'
   }
@@ -119,5 +118,9 @@ export default class FfaListingsModule extends VuexModule {
     const titles = this.candidates.map((c) => c.title)
     titles.concat(this.listed.map((l) => l.title))
     return titles
+  }
+
+  get allListings(): FfaListing[] {
+    return this.candidates.concat(this.listed)
   }
 }

--- a/tests/unit/components/listing/FfaListingComponent.spec.ts
+++ b/tests/unit/components/listing/FfaListingComponent.spec.ts
@@ -31,112 +31,112 @@ describe('FfaListingComponent.vue', () => {
   })
 
   describe('renderList()', () => {
-    // it('correctly renders user candidate listings when given address and candidate props', async () => {
-    //   wrapper = mount(FfaListingComponent, {
-    //     attachToDocument: true,
-    //     store: appStore,
-    //     propsData: {
-    //       status: FfaListingStatus.candidate,
-    //       userAddress,
-    //     },
-    //   })
+    it('correctly renders user candidate listings when given address and candidate props', async () => {
+      wrapper = mount(FfaListingComponent, {
+        attachToDocument: true,
+        store: appStore,
+        propsData: {
+          status: FfaListingStatus.candidate,
+          userAddress,
+        },
+      })
 
-    //   // @ts-ignore
-    //   await wrapper.vm.renderList()
+      // @ts-ignore
+      await wrapper.vm.renderList()
 
-    //   const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
-    //   const nonCandidates = candidateAttributeWrapperArray.filter((wrapped) => {
-    //     return wrapped.text() !== FfaListingStatus.candidate
-    //   })
-    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(5)
-    //   expect(candidateAttributeWrapperArray.length).toBe(5)
-    //   expect(nonCandidates.length).toBe(0)
-    // })
+      const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
+      const nonCandidates = candidateAttributeWrapperArray.filter((wrapped) => {
+        return wrapped.text() !== FfaListingStatus.candidate
+      })
+      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(5)
+      expect(candidateAttributeWrapperArray.length).toBe(5)
+      expect(nonCandidates.length).toBe(0)
+    })
 
-    // it('correctly renders user listed listings when given address and listed props', () => {
-    //   wrapper = mount(FfaListingComponent, {
-    //     attachToDocument: true,
-    //     store: appStore,
-    //     propsData: {
-    //       status: FfaListingStatus.listed,
-    //       userAddress,
-    //     },
-    //   })
+    it('correctly renders user listed listings when given address and listed props', () => {
+      wrapper = mount(FfaListingComponent, {
+        attachToDocument: true,
+        store: appStore,
+        propsData: {
+          status: FfaListingStatus.listed,
+          userAddress,
+        },
+      })
 
-    //   // @ts-ignore
-    //   wrapper.vm.renderList()
+      // @ts-ignore
+      wrapper.vm.renderList()
 
-    //   const listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
-    //   const nonListed = listedAttributeWrapperArray.filter((wrapped) => {
-    //     return wrapped.text() !== FfaListingStatus.listed
-    //   })
-    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(4)
-    //   expect(listedAttributeWrapperArray.length).toBe(4)
-    //   expect(nonListed.length).toBe(0)
-    // })
+      const listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
+      const nonListed = listedAttributeWrapperArray.filter((wrapped) => {
+        return wrapped.text() !== FfaListingStatus.listed
+      })
+      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(4)
+      expect(listedAttributeWrapperArray.length).toBe(4)
+      expect(nonListed.length).toBe(0)
+    })
 
-    // it('correctly renders all user listings when given address and listed props', () => {
-    //   wrapper = mount(FfaListingComponent, {
-    //     attachToDocument: true,
-    //     store: appStore,
-    //     propsData: { userAddress },
-    //   })
-    //   // @ts-ignore
-    //   wrapper.vm.renderList()
+    it('correctly renders all user listings when given address and listed props', () => {
+      wrapper = mount(FfaListingComponent, {
+        attachToDocument: true,
+        store: appStore,
+        propsData: { userAddress },
+      })
+      // @ts-ignore
+      wrapper.vm.renderList()
 
-    //   const ownerAttributeWrapperArray = wrapper.findAll(ownerAttribute)
-    //   const nonOwned = ownerAttributeWrapperArray.filter((wrapped) => wrapped.text() !== userAddress)
-    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(9)
-    //   expect(ownerAttributeWrapperArray.length).toBe(9)
-    //   expect(nonOwned.length).toBe(0)
-    // })
+      const ownerAttributeWrapperArray = wrapper.findAll(ownerAttribute)
+      const nonOwned = ownerAttributeWrapperArray.filter((wrapped) => wrapped.text() !== userAddress)
+      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(9)
+      expect(ownerAttributeWrapperArray.length).toBe(9)
+      expect(nonOwned.length).toBe(0)
+    })
 
-    // it('correctly renders all candidate listings when given candidate props', () => {
-    //   wrapper = mount(FfaListingComponent, {
-    //     attachToDocument: true,
-    //     store: appStore,
-    //     propsData: { status: FfaListingStatus.candidate },
-    //   })
-    //   // @ts-ignore
-    //   wrapper.vm.renderList()
+    it('correctly renders all candidate listings when given candidate props', () => {
+      wrapper = mount(FfaListingComponent, {
+        attachToDocument: true,
+        store: appStore,
+        propsData: { status: FfaListingStatus.candidate },
+      })
+      // @ts-ignore
+      wrapper.vm.renderList()
 
-    //   const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
-    //   const nonCandidates = candidateAttributeWrapperArray.filter((wrapped) => {
-    //     return wrapped.text() !== FfaListingStatus.candidate
-    //   })
-    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(6)
-    //   expect(candidateAttributeWrapperArray.length).toBe(6)
-    //   expect(nonCandidates.length).toBe(0)
-    // })
+      const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
+      const nonCandidates = candidateAttributeWrapperArray.filter((wrapped) => {
+        return wrapped.text() !== FfaListingStatus.candidate
+      })
+      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(6)
+      expect(candidateAttributeWrapperArray.length).toBe(6)
+      expect(nonCandidates.length).toBe(0)
+    })
 
-    // it('correctly renders all listed listings when given listed props', () => {
-    //   wrapper = mount(FfaListingComponent, {
-    //     attachToDocument: true,
-    //     store: appStore,
-    //     propsData: { status: FfaListingStatus.listed },
-    //   })
-    //   // @ts-ignore
-    //   wrapper.vm.renderList()
+    it('correctly renders all listed listings when given listed props', () => {
+      wrapper = mount(FfaListingComponent, {
+        attachToDocument: true,
+        store: appStore,
+        propsData: { status: FfaListingStatus.listed },
+      })
+      // @ts-ignore
+      wrapper.vm.renderList()
 
-    //   const listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
-    //   const nonListed = listedAttributeWrapperArray.filter((wrapped) => {
-    //     return wrapped.text() !== FfaListingStatus.listed
-    //   })
-    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(7)
-    //   expect(listedAttributeWrapperArray.length).toBe(7)
-    //   expect(nonListed.length).toBe(0)
-    // })
+      const listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
+      const nonListed = listedAttributeWrapperArray.filter((wrapped) => {
+        return wrapped.text() !== FfaListingStatus.listed
+      })
+      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(7)
+      expect(listedAttributeWrapperArray.length).toBe(7)
+      expect(nonListed.length).toBe(0)
+    })
 
-    // it('correctly renders all listings when given not given props', () => {
-    //   wrapper = shallowMount(FfaListingComponent, {
-    //     attachToDocument: true,
-    //     store: appStore,
-    //   })
+    it('correctly renders all listings when given not given props', () => {
+      wrapper = shallowMount(FfaListingComponent, {
+        attachToDocument: true,
+        store: appStore,
+      })
 
-    //   // @ts-ignore
-    //   wrapper.vm.renderList()
-    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(13)
-    // })
+      // @ts-ignore
+      wrapper.vm.renderList()
+      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(13)
+    })
 
     // @ts-ignore
     it('correctly reacts to addCandidate(), removeCandidate(), setCandidate(), promoteCandidate()', async () => {
@@ -176,6 +176,37 @@ describe('FfaListingComponent.vue', () => {
       expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(2)
       expect(candidateAttributeWrapperArray.length).toBe(1)
       expect(listedAttributeWrapperArray.length).toBe(1)
+    })
+
+    it('correctly reacts to setListed(), addToListed(), removeFromListed(), ', async () => {
+      wrapper = mount(FfaListingComponent, {
+        attachToDocument: true,
+        store: appStore,
+      })
+      const ffaListingsModule = getModule(FfalistingsModule, appStore)
+      ffaListingsModule.clearAll()
+    // tslint:disable:max-line-length
+      const file0 = new FfaListing('title0', 'description0', 'type0', 'hash0', 'md50', [], FfaListingStatus.listed, '0xwall3t')
+      const file1 = new FfaListing('title1', 'description1', 'type1', 'hash1', 'md51', [], FfaListingStatus.listed, '0xwall3t')
+    // tslint:enable:max-line-length
+
+      ffaListingsModule.addToListed(file0)
+
+      let listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
+      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(1)
+      expect(listedAttributeWrapperArray.length).toBe(1)
+
+      ffaListingsModule.removeFromListed(file0)
+
+      listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
+      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(0)
+      expect(listedAttributeWrapperArray.length).toBe(0)
+
+      ffaListingsModule.setListed([file0, file1])
+
+      listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
+      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(2)
+      expect(listedAttributeWrapperArray.length).toBe(2)
     })
   })
 })

--- a/tests/unit/components/listing/FfaListingComponent.spec.ts
+++ b/tests/unit/components/listing/FfaListingComponent.spec.ts
@@ -132,29 +132,29 @@ describe('FfaListingComponent.vue', () => {
       expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(13)
     })
 
-  //   it('correctly reacts to vuex state mutation', async () => {
-  //     wrapper = mount(FfaListingComponent, {
-  //       attachToDocument: true,
-  //       store: appStore,
-  //     })
+    // it('correctly reacts to vuex state mutation', async () => {
+    //   wrapper = mount(FfaListingComponent, {
+    //     attachToDocument: true,
+    //     store: appStore,
+    //   })
 
-  //     const ffaListingsModule = getModule(FfalistingsModule, appStore)
-  //     const file1 = new FfaListing('title1',
-  //                                  'description1',
-  //                                  'type1',
-  //                                  'hash1',
-  //                                  'md51',
-  //                                  [],
-  //                                  FfaListingStatus.candidate,
-  //                                  '0xwall3t')
+    //   const ffaListingsModule = getModule(FfalistingsModule, appStore)
+    //   const file1 = new FfaListing('title1',
+    //                                'description1',
+    //                                'type1',
+    //                                'hash1',
+    //                                'md51',
+    //                                [],
+    //                                FfaListingStatus.candidate,
+    //                                '0xwall3t')
 
-  //     ffaListingsModule.addCandidate(file1)
+    //   ffaListingsModule.addCandidate(file1)
 
 
-  //     const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
-  //     expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(1)
-  //     expect(candidateAttributeWrapperArray.length).toBe(1)
-  //   })
+    //   const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
+    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(1)
+    //   expect(candidateAttributeWrapperArray.length).toBe(1)
+    // })
   })
 })
 

--- a/tests/unit/components/listing/FfaListingComponent.spec.ts
+++ b/tests/unit/components/listing/FfaListingComponent.spec.ts
@@ -1,24 +1,33 @@
 import VueRouter from 'vue-router'
-import { shallowMount, createLocalVue, mount } from '@vue/test-utils'
+import { shallowMount, createLocalVue, mount, Wrapper} from '@vue/test-utils'
 import FfaListingComponent from '../../../../src/components/ui/FfaListingComponent.vue'
 import appStore from '../../../../src/store'
 import FfaListing, { FfaListingStatus} from '../../../../src/models/FfaListing'
+import { getModule } from 'vuex-module-decorators'
+import FfalistingsModule from '../../../../src/vuexModules/FfaListingsModule'
 
 const localVue = createLocalVue()
 const ffaListingClass = '.ffa-listing'
 const userAddress = '0xwall3t'
-const statusAttribute = '[data-property="status"]'
+const listedAttribute = 'span[data-status="listed"]'
+const candidateAttribute = 'span[data-status="candidate"]'
 const ownerAttribute = '[data-property="owner"]'
 
 describe('FfaListingComponent.vue', () => {
+
+  let wrapper!: Wrapper<FfaListingComponent>
 
   beforeAll(() => {
     localVue.use(VueRouter)
   })
 
+  afterEach(() => {
+    wrapper.destroy()
+  })
+
   describe('renderList()', () => {
     it('correctly renders user candidate listings when given address and candidate props', async () => {
-      const wrapper = mount(FfaListingComponent, {
+      wrapper = mount(FfaListingComponent, {
         attachToDocument: true,
         store: appStore,
         propsData: {
@@ -26,20 +35,21 @@ describe('FfaListingComponent.vue', () => {
           userAddress,
         },
       })
+
       // @ts-ignore
       await wrapper.vm.renderList()
 
-      const statusAttributeWrapperArray = wrapper.findAll(statusAttribute)
-      const nonCandidates = statusAttributeWrapperArray.filter((wrapped) => {
+      const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
+      const nonCandidates = candidateAttributeWrapperArray.filter((wrapped) => {
         return wrapped.text() !== FfaListingStatus.candidate
       })
       expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(5)
-      expect(statusAttributeWrapperArray.length).toBe(5)
+      expect(candidateAttributeWrapperArray.length).toBe(5)
       expect(nonCandidates.length).toBe(0)
     })
 
     it('correctly renders user listed listings when given address and listed props', async () => {
-      const wrapper = mount(FfaListingComponent, {
+      wrapper = mount(FfaListingComponent, {
         attachToDocument: true,
         store: appStore,
         propsData: {
@@ -50,17 +60,17 @@ describe('FfaListingComponent.vue', () => {
       // @ts-ignore
       await wrapper.vm.renderList()
 
-      const statusAttributeWrapperArray = wrapper.findAll(statusAttribute)
-      const nonListed = statusAttributeWrapperArray.filter((wrapped) => {
+      const listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
+      const nonListed = listedAttributeWrapperArray.filter((wrapped) => {
         return wrapped.text() !== FfaListingStatus.listed
       })
       expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(4)
-      expect(statusAttributeWrapperArray.length).toBe(4)
+      expect(listedAttributeWrapperArray.length).toBe(4)
       expect(nonListed.length).toBe(0)
     })
 
     it('correctly renders all user listings when given address and listed props', async () => {
-      const wrapper = mount(FfaListingComponent, {
+      wrapper = mount(FfaListingComponent, {
         attachToDocument: true,
         store: appStore,
         propsData: { userAddress },
@@ -69,14 +79,14 @@ describe('FfaListingComponent.vue', () => {
       await wrapper.vm.renderList()
 
       const ownerAttributeWrapperArray = wrapper.findAll(ownerAttribute)
-      const nonOwned = ownerAttributeWrapperArray.filter((wrapped) => (wrapped.text() !== userAddress))
+      const nonOwned = ownerAttributeWrapperArray.filter((wrapped) => wrapped.text() !== userAddress)
       expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(9)
       expect(ownerAttributeWrapperArray.length).toBe(9)
       expect(nonOwned.length).toBe(0)
     })
 
     it('correctly renders all candidate listings when given candidate props', async () => {
-      const wrapper = mount(FfaListingComponent, {
+      wrapper = mount(FfaListingComponent, {
         attachToDocument: true,
         store: appStore,
         propsData: { status: FfaListingStatus.candidate },
@@ -84,17 +94,17 @@ describe('FfaListingComponent.vue', () => {
       // @ts-ignore
       await wrapper.vm.renderList()
 
-      const statusAttributeWrapperArray = wrapper.findAll(statusAttribute)
-      const nonCandidates = statusAttributeWrapperArray.filter((wrapped) => {
+      const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
+      const nonCandidates = candidateAttributeWrapperArray.filter((wrapped) => {
         return wrapped.text() !== FfaListingStatus.candidate
       })
       expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(6)
-      expect(statusAttributeWrapperArray.length).toBe(6)
+      expect(candidateAttributeWrapperArray.length).toBe(6)
       expect(nonCandidates.length).toBe(0)
     })
 
     it('correctly renders all listed listings when given listed props', async () => {
-      const wrapper = mount(FfaListingComponent, {
+      wrapper = mount(FfaListingComponent, {
         attachToDocument: true,
         store: appStore,
         propsData: { status: FfaListingStatus.listed },
@@ -102,17 +112,17 @@ describe('FfaListingComponent.vue', () => {
       // @ts-ignore
       await wrapper.vm.renderList()
 
-      const statusAttributeWrapperArray = wrapper.findAll(statusAttribute)
-      const nonListed = statusAttributeWrapperArray.filter((wrapped) => {
+      const listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
+      const nonListed = listedAttributeWrapperArray.filter((wrapped) => {
         return wrapped.text() !== FfaListingStatus.listed
       })
       expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(7)
-      expect(statusAttributeWrapperArray.length).toBe(7)
+      expect(listedAttributeWrapperArray.length).toBe(7)
       expect(nonListed.length).toBe(0)
     })
 
     it('correctly renders all listings when given not given props', async () => {
-      const wrapper = mount(FfaListingComponent, {
+      wrapper = shallowMount(FfaListingComponent, {
         attachToDocument: true,
         store: appStore,
       })
@@ -121,5 +131,33 @@ describe('FfaListingComponent.vue', () => {
       await wrapper.vm.renderList()
       expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(13)
     })
+
+  //   it('correctly reacts to vuex state mutation', async () => {
+  //     wrapper = mount(FfaListingComponent, {
+  //       attachToDocument: true,
+  //       store: appStore,
+  //     })
+
+  //     const ffaListingsModule = getModule(FfalistingsModule, appStore)
+  //     const file1 = new FfaListing('title1',
+  //                                  'description1',
+  //                                  'type1',
+  //                                  'hash1',
+  //                                  'md51',
+  //                                  [],
+  //                                  FfaListingStatus.candidate,
+  //                                  '0xwall3t')
+
+  //     ffaListingsModule.addCandidate(file1)
+
+
+  //     const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
+  //     expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(1)
+  //     expect(candidateAttributeWrapperArray.length).toBe(1)
+  //   })
   })
 })
+
+// function delay(ms: number): Promise<any> {
+//   return new Promise( (resolve) => setTimeout(resolve, ms) )
+// }

--- a/tests/unit/components/listing/FfaListingComponent.spec.ts
+++ b/tests/unit/components/listing/FfaListingComponent.spec.ts
@@ -5,6 +5,7 @@ import appStore from '../../../../src/store'
 import FfaListing, { FfaListingStatus} from '../../../../src/models/FfaListing'
 import { getModule } from 'vuex-module-decorators'
 import FfalistingsModule from '../../../../src/vuexModules/FfaListingsModule'
+import FfaListingsModule from '../../../../src/vuexModules/FfaListingsModule'
 
 const localVue = createLocalVue()
 const ffaListingClass = '.ffa-listing'
@@ -17,9 +18,13 @@ describe('FfaListingComponent.vue', () => {
 
   let wrapper!: Wrapper<FfaListingComponent>
 
-  beforeAll(() => {
+  beforeAll(async () => {
     localVue.use(VueRouter)
+    const ffaListingsModule = getModule(FfalistingsModule, appStore)
+    await ffaListingsModule.fetchCandidates()
+    await ffaListingsModule.fetchListed()
   })
+
 
   afterEach(() => {
     wrapper.destroy()
@@ -57,6 +62,7 @@ describe('FfaListingComponent.vue', () => {
           userAddress,
         },
       })
+
       // @ts-ignore
       await wrapper.vm.renderList()
 

--- a/tests/unit/components/listing/FfaListingComponent.spec.ts
+++ b/tests/unit/components/listing/FfaListingComponent.spec.ts
@@ -31,139 +31,155 @@ describe('FfaListingComponent.vue', () => {
   })
 
   describe('renderList()', () => {
-    it('correctly renders user candidate listings when given address and candidate props', async () => {
-      wrapper = mount(FfaListingComponent, {
-        attachToDocument: true,
-        store: appStore,
-        propsData: {
-          status: FfaListingStatus.candidate,
-          userAddress,
-        },
-      })
-
-      // @ts-ignore
-      await wrapper.vm.renderList()
-
-      const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
-      const nonCandidates = candidateAttributeWrapperArray.filter((wrapped) => {
-        return wrapped.text() !== FfaListingStatus.candidate
-      })
-      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(5)
-      expect(candidateAttributeWrapperArray.length).toBe(5)
-      expect(nonCandidates.length).toBe(0)
-    })
-
-    it('correctly renders user listed listings when given address and listed props', () => {
-      wrapper = mount(FfaListingComponent, {
-        attachToDocument: true,
-        store: appStore,
-        propsData: {
-          status: FfaListingStatus.listed,
-          userAddress,
-        },
-      })
-
-      // @ts-ignore
-      wrapper.vm.renderList()
-
-      const listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
-      const nonListed = listedAttributeWrapperArray.filter((wrapped) => {
-        return wrapped.text() !== FfaListingStatus.listed
-      })
-      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(4)
-      expect(listedAttributeWrapperArray.length).toBe(4)
-      expect(nonListed.length).toBe(0)
-    })
-
-    it('correctly renders all user listings when given address and listed props', () => {
-      wrapper = mount(FfaListingComponent, {
-        attachToDocument: true,
-        store: appStore,
-        propsData: { userAddress },
-      })
-      // @ts-ignore
-      wrapper.vm.renderList()
-
-      const ownerAttributeWrapperArray = wrapper.findAll(ownerAttribute)
-      const nonOwned = ownerAttributeWrapperArray.filter((wrapped) => wrapped.text() !== userAddress)
-      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(9)
-      expect(ownerAttributeWrapperArray.length).toBe(9)
-      expect(nonOwned.length).toBe(0)
-    })
-
-    it('correctly renders all candidate listings when given candidate props', () => {
-      wrapper = mount(FfaListingComponent, {
-        attachToDocument: true,
-        store: appStore,
-        propsData: { status: FfaListingStatus.candidate },
-      })
-      // @ts-ignore
-      wrapper.vm.renderList()
-
-      const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
-      const nonCandidates = candidateAttributeWrapperArray.filter((wrapped) => {
-        return wrapped.text() !== FfaListingStatus.candidate
-      })
-      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(6)
-      expect(candidateAttributeWrapperArray.length).toBe(6)
-      expect(nonCandidates.length).toBe(0)
-    })
-
-    it('correctly renders all listed listings when given listed props', () => {
-      wrapper = mount(FfaListingComponent, {
-        attachToDocument: true,
-        store: appStore,
-        propsData: { status: FfaListingStatus.listed },
-      })
-      // @ts-ignore
-      wrapper.vm.renderList()
-
-      const listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
-      const nonListed = listedAttributeWrapperArray.filter((wrapped) => {
-        return wrapped.text() !== FfaListingStatus.listed
-      })
-      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(7)
-      expect(listedAttributeWrapperArray.length).toBe(7)
-      expect(nonListed.length).toBe(0)
-    })
-
-    it('correctly renders all listings when given not given props', () => {
-      wrapper = shallowMount(FfaListingComponent, {
-        attachToDocument: true,
-        store: appStore,
-      })
-
-      // @ts-ignore
-      wrapper.vm.renderList()
-      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(13)
-    })
-
-    // it('correctly reacts to vuex state mutation', async () => {
+    // it('correctly renders user candidate listings when given address and candidate props', async () => {
     //   wrapper = mount(FfaListingComponent, {
+    //     attachToDocument: true,
+    //     store: appStore,
+    //     propsData: {
+    //       status: FfaListingStatus.candidate,
+    //       userAddress,
+    //     },
+    //   })
+
+    //   // @ts-ignore
+    //   await wrapper.vm.renderList()
+
+    //   const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
+    //   const nonCandidates = candidateAttributeWrapperArray.filter((wrapped) => {
+    //     return wrapped.text() !== FfaListingStatus.candidate
+    //   })
+    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(5)
+    //   expect(candidateAttributeWrapperArray.length).toBe(5)
+    //   expect(nonCandidates.length).toBe(0)
+    // })
+
+    // it('correctly renders user listed listings when given address and listed props', () => {
+    //   wrapper = mount(FfaListingComponent, {
+    //     attachToDocument: true,
+    //     store: appStore,
+    //     propsData: {
+    //       status: FfaListingStatus.listed,
+    //       userAddress,
+    //     },
+    //   })
+
+    //   // @ts-ignore
+    //   wrapper.vm.renderList()
+
+    //   const listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
+    //   const nonListed = listedAttributeWrapperArray.filter((wrapped) => {
+    //     return wrapped.text() !== FfaListingStatus.listed
+    //   })
+    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(4)
+    //   expect(listedAttributeWrapperArray.length).toBe(4)
+    //   expect(nonListed.length).toBe(0)
+    // })
+
+    // it('correctly renders all user listings when given address and listed props', () => {
+    //   wrapper = mount(FfaListingComponent, {
+    //     attachToDocument: true,
+    //     store: appStore,
+    //     propsData: { userAddress },
+    //   })
+    //   // @ts-ignore
+    //   wrapper.vm.renderList()
+
+    //   const ownerAttributeWrapperArray = wrapper.findAll(ownerAttribute)
+    //   const nonOwned = ownerAttributeWrapperArray.filter((wrapped) => wrapped.text() !== userAddress)
+    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(9)
+    //   expect(ownerAttributeWrapperArray.length).toBe(9)
+    //   expect(nonOwned.length).toBe(0)
+    // })
+
+    // it('correctly renders all candidate listings when given candidate props', () => {
+    //   wrapper = mount(FfaListingComponent, {
+    //     attachToDocument: true,
+    //     store: appStore,
+    //     propsData: { status: FfaListingStatus.candidate },
+    //   })
+    //   // @ts-ignore
+    //   wrapper.vm.renderList()
+
+    //   const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
+    //   const nonCandidates = candidateAttributeWrapperArray.filter((wrapped) => {
+    //     return wrapped.text() !== FfaListingStatus.candidate
+    //   })
+    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(6)
+    //   expect(candidateAttributeWrapperArray.length).toBe(6)
+    //   expect(nonCandidates.length).toBe(0)
+    // })
+
+    // it('correctly renders all listed listings when given listed props', () => {
+    //   wrapper = mount(FfaListingComponent, {
+    //     attachToDocument: true,
+    //     store: appStore,
+    //     propsData: { status: FfaListingStatus.listed },
+    //   })
+    //   // @ts-ignore
+    //   wrapper.vm.renderList()
+
+    //   const listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
+    //   const nonListed = listedAttributeWrapperArray.filter((wrapped) => {
+    //     return wrapped.text() !== FfaListingStatus.listed
+    //   })
+    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(7)
+    //   expect(listedAttributeWrapperArray.length).toBe(7)
+    //   expect(nonListed.length).toBe(0)
+    // })
+
+    // it('correctly renders all listings when given not given props', () => {
+    //   wrapper = shallowMount(FfaListingComponent, {
     //     attachToDocument: true,
     //     store: appStore,
     //   })
 
-    //   const ffaListingsModule = getModule(FfalistingsModule, appStore)
-    //   const file1 = new FfaListing('title1',
-    //                                'description1',
-    //                                'type1',
-    //                                'hash1',
-    //                                'md51',
-    //                                [],
-    //                                FfaListingStatus.candidate,
-    //                                '0xwall3t')
-
-    //   ffaListingsModule.addCandidate(file1)
-
-
-    //   const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
-    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(1)
-    //   expect(candidateAttributeWrapperArray.length).toBe(1)
+    //   // @ts-ignore
+    //   wrapper.vm.renderList()
+    //   expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(13)
     // })
+
+    // @ts-ignore
+    it('correctly reacts to addCandidate(), removeCandidate(), setCandidate(), promoteCandidate()', async () => {
+      wrapper = mount(FfaListingComponent, {
+        attachToDocument: true,
+        store: appStore,
+      })
+      const ffaListingsModule = getModule(FfalistingsModule, appStore)
+    // tslint:disable:max-line-length
+      const file0 = new FfaListing('title0', 'description0', 'type0', 'hash0', 'md50', [], FfaListingStatus.candidate, '0xwall3t')
+      const file1 = new FfaListing('title1', 'description1', 'type1', 'hash1', 'md51', [], FfaListingStatus.candidate, '0xwall3t')
+    // tslint:enable:max-line-length
+      ffaListingsModule.clearAll()
+      ffaListingsModule.addCandidate(file0)
+      await delay(10)
+
+      let candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
+      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(1)
+      expect(candidateAttributeWrapperArray.length).toBe(1)
+
+      ffaListingsModule.removeCandidate(file0)
+
+      candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
+      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(0)
+      expect(candidateAttributeWrapperArray.length).toBe(0)
+
+      ffaListingsModule.setCandidates([file0, file1])
+
+      candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
+      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(2)
+      expect(candidateAttributeWrapperArray.length).toBe(2)
+
+      ffaListingsModule.promoteCandidate(file1)
+
+      candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
+      const listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
+      expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(2)
+      expect(candidateAttributeWrapperArray.length).toBe(1)
+      expect(listedAttributeWrapperArray.length).toBe(1)
+    })
   })
 })
 
-// function delay(ms: number): Promise<any> {
-//   return new Promise( (resolve) => setTimeout(resolve, ms) )
-// }
+function delay(ms: number): Promise<any> {
+  return new Promise( (resolve) => setTimeout(resolve, ms) )
+}

--- a/tests/unit/components/listing/FfaListingComponent.spec.ts
+++ b/tests/unit/components/listing/FfaListingComponent.spec.ts
@@ -5,7 +5,6 @@ import appStore from '../../../../src/store'
 import FfaListing, { FfaListingStatus} from '../../../../src/models/FfaListing'
 import { getModule } from 'vuex-module-decorators'
 import FfalistingsModule from '../../../../src/vuexModules/FfaListingsModule'
-import FfaListingsModule from '../../../../src/vuexModules/FfaListingsModule'
 
 const localVue = createLocalVue()
 const ffaListingClass = '.ffa-listing'

--- a/tests/unit/components/listing/FfaListingComponent.spec.ts
+++ b/tests/unit/components/listing/FfaListingComponent.spec.ts
@@ -1,6 +1,6 @@
 import VueRouter from 'vue-router'
 import { shallowMount, createLocalVue, mount, Wrapper} from '@vue/test-utils'
-import FfaListingComponent from '../../../../src/components/ui/FfaListingComponent.vue'
+import FfaListingsComponent from '../../../../src/components/ui/FfaListingsComponent.vue'
 import appStore from '../../../../src/store'
 import FfaListing, { FfaListingStatus} from '../../../../src/models/FfaListing'
 import { getModule } from 'vuex-module-decorators'
@@ -13,9 +13,9 @@ const listedAttribute = 'span[data-status="listed"]'
 const candidateAttribute = 'span[data-status="candidate"]'
 const ownerAttribute = '[data-property="owner"]'
 
-describe('FfaListingComponent.vue', () => {
+describe('FfaListingsComponent.vue', () => {
 
-  let wrapper!: Wrapper<FfaListingComponent>
+  let wrapper!: Wrapper<FfaListingsComponent>
 
   beforeAll(async () => {
     localVue.use(VueRouter)
@@ -31,7 +31,7 @@ describe('FfaListingComponent.vue', () => {
 
   describe('renderList()', () => {
     it('correctly renders user candidate listings when given address and candidate props', async () => {
-      wrapper = mount(FfaListingComponent, {
+      wrapper = mount(FfaListingsComponent, {
         attachToDocument: true,
         store: appStore,
         propsData: {
@@ -53,7 +53,7 @@ describe('FfaListingComponent.vue', () => {
     })
 
     it('correctly renders user listed listings when given address and listed props', () => {
-      wrapper = mount(FfaListingComponent, {
+      wrapper = mount(FfaListingsComponent, {
         attachToDocument: true,
         store: appStore,
         propsData: {
@@ -75,7 +75,7 @@ describe('FfaListingComponent.vue', () => {
     })
 
     it('correctly renders all user listings when given address and listed props', () => {
-      wrapper = mount(FfaListingComponent, {
+      wrapper = mount(FfaListingsComponent, {
         attachToDocument: true,
         store: appStore,
         propsData: { userAddress },
@@ -91,7 +91,7 @@ describe('FfaListingComponent.vue', () => {
     })
 
     it('correctly renders all candidate listings when given candidate props', () => {
-      wrapper = mount(FfaListingComponent, {
+      wrapper = mount(FfaListingsComponent, {
         attachToDocument: true,
         store: appStore,
         propsData: { status: FfaListingStatus.candidate },
@@ -109,7 +109,7 @@ describe('FfaListingComponent.vue', () => {
     })
 
     it('correctly renders all listed listings when given listed props', () => {
-      wrapper = mount(FfaListingComponent, {
+      wrapper = mount(FfaListingsComponent, {
         attachToDocument: true,
         store: appStore,
         propsData: { status: FfaListingStatus.listed },
@@ -127,7 +127,7 @@ describe('FfaListingComponent.vue', () => {
     })
 
     it('correctly renders all listings when given not given props', () => {
-      wrapper = shallowMount(FfaListingComponent, {
+      wrapper = shallowMount(FfaListingsComponent, {
         attachToDocument: true,
         store: appStore,
       })
@@ -139,7 +139,7 @@ describe('FfaListingComponent.vue', () => {
 
     // @ts-ignore
     it('correctly reacts to addCandidate(), removeCandidate(), setCandidate(), promoteCandidate()', async () => {
-      wrapper = mount(FfaListingComponent, {
+      wrapper = mount(FfaListingsComponent, {
         attachToDocument: true,
         store: appStore,
       })
@@ -178,7 +178,7 @@ describe('FfaListingComponent.vue', () => {
     })
 
     it('correctly reacts to setListed(), addToListed(), removeFromListed(), ', async () => {
-      wrapper = mount(FfaListingComponent, {
+      wrapper = mount(FfaListingsComponent, {
         attachToDocument: true,
         store: appStore,
       })

--- a/tests/unit/components/listing/FfaListingComponent.spec.ts
+++ b/tests/unit/components/listing/FfaListingComponent.spec.ts
@@ -53,7 +53,7 @@ describe('FfaListingComponent.vue', () => {
       expect(nonCandidates.length).toBe(0)
     })
 
-    it('correctly renders user listed listings when given address and listed props', async () => {
+    it('correctly renders user listed listings when given address and listed props', () => {
       wrapper = mount(FfaListingComponent, {
         attachToDocument: true,
         store: appStore,
@@ -64,7 +64,7 @@ describe('FfaListingComponent.vue', () => {
       })
 
       // @ts-ignore
-      await wrapper.vm.renderList()
+      wrapper.vm.renderList()
 
       const listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
       const nonListed = listedAttributeWrapperArray.filter((wrapped) => {
@@ -75,14 +75,14 @@ describe('FfaListingComponent.vue', () => {
       expect(nonListed.length).toBe(0)
     })
 
-    it('correctly renders all user listings when given address and listed props', async () => {
+    it('correctly renders all user listings when given address and listed props', () => {
       wrapper = mount(FfaListingComponent, {
         attachToDocument: true,
         store: appStore,
         propsData: { userAddress },
       })
       // @ts-ignore
-      await wrapper.vm.renderList()
+      wrapper.vm.renderList()
 
       const ownerAttributeWrapperArray = wrapper.findAll(ownerAttribute)
       const nonOwned = ownerAttributeWrapperArray.filter((wrapped) => wrapped.text() !== userAddress)
@@ -91,14 +91,14 @@ describe('FfaListingComponent.vue', () => {
       expect(nonOwned.length).toBe(0)
     })
 
-    it('correctly renders all candidate listings when given candidate props', async () => {
+    it('correctly renders all candidate listings when given candidate props', () => {
       wrapper = mount(FfaListingComponent, {
         attachToDocument: true,
         store: appStore,
         propsData: { status: FfaListingStatus.candidate },
       })
       // @ts-ignore
-      await wrapper.vm.renderList()
+      wrapper.vm.renderList()
 
       const candidateAttributeWrapperArray = wrapper.findAll(candidateAttribute)
       const nonCandidates = candidateAttributeWrapperArray.filter((wrapped) => {
@@ -109,14 +109,14 @@ describe('FfaListingComponent.vue', () => {
       expect(nonCandidates.length).toBe(0)
     })
 
-    it('correctly renders all listed listings when given listed props', async () => {
+    it('correctly renders all listed listings when given listed props', () => {
       wrapper = mount(FfaListingComponent, {
         attachToDocument: true,
         store: appStore,
         propsData: { status: FfaListingStatus.listed },
       })
       // @ts-ignore
-      await wrapper.vm.renderList()
+      wrapper.vm.renderList()
 
       const listedAttributeWrapperArray = wrapper.findAll(listedAttribute)
       const nonListed = listedAttributeWrapperArray.filter((wrapped) => {
@@ -127,14 +127,14 @@ describe('FfaListingComponent.vue', () => {
       expect(nonListed.length).toBe(0)
     })
 
-    it('correctly renders all listings when given not given props', async () => {
+    it('correctly renders all listings when given not given props', () => {
       wrapper = shallowMount(FfaListingComponent, {
         attachToDocument: true,
         store: appStore,
       })
 
       // @ts-ignore
-      await wrapper.vm.renderList()
+      wrapper.vm.renderList()
       expect(wrapper.findAll(`${ffaListingClass}`).length).toBe(13)
     })
 


### PR DESCRIPTION
For #151 

1. Remove a ton of the `async/await` calls from `FfaListingComponent`.
2. Convert `if` statements to `switch/case`, fix formatting within `renderList()`. 
3. `MutationActions` called in the specs when data is needed.
4. Was able to catch a bug during candidate promotion. Previously `FfaListings` still had a candidate `status` even after promotion. 
5. Added tests to test  `FfaListingComponent` reactivity to `FfaListingsModule` mutation.
6. Refactor `data-` attributes. Added guard for `vuexSubscriptions()`