### PR TITLE
Correct datatrust contract address

### DIFF
--- a/src/models/ContractAddresses.ts
+++ b/src/models/ContractAddresses.ts
@@ -5,5 +5,5 @@ export default class ContractsAddresses {
   public static VotingAddress = '0x8109439D3A250f886379388CB6E29bBF64018255'
   public static P11rAddress = '0xa13811BfdD6B8D7d28efD954Cd604ECA876f91fD'
   public static ReserveAddress = '0x9D52198D2eb8C57363D91c2BdFC9768be6D2d191'
-  public static DatatrustAddress = '0xEF1Df5D48F08f25ADF297fF5dee5694b6C6599DE'
+  public static DatatrustAddress = '0xD9c1120FA4f001d10A6209210EF408733d07B392'
 }


### PR DESCRIPTION
Corrected datatrust contract address. Confirmed all of them are now correct.