### PR TITLE
Fixes #514 - Can't select listing tab in `FfaCandidateView`

### DIFF
--- a/src/components/ui/RouterTabs.vue
+++ b/src/components/ui/RouterTabs.vue
@@ -22,6 +22,8 @@ import { Component, Vue, Prop, Watch } from 'vue-property-decorator'
 import RouterTabMapping from '../../models/RouterTabMapping'
 import { NoCache } from 'vue-class-decorator'
 
+import { CloseDrawer } from '../../models/Events'
+
 @Component
 export default class RouterTabs extends Vue {
 
@@ -53,6 +55,8 @@ export default class RouterTabs extends Vue {
     if (resolved.route.name === this.$router.currentRoute.name) {
       return
     }
+
+    this.$root.$emit(CloseDrawer)
     this.$router.push(resolved.location)
   }
 

--- a/src/functionModules/router/RouterTransitionModule.ts
+++ b/src/functionModules/router/RouterTransitionModule.ts
@@ -1,12 +1,7 @@
-
 import { Route } from 'vue-router'
 import Vue from 'vue'
-import { getModule } from 'vuex-module-decorators'
-import NewListingModule from '../../vuexModules/NewListingModule'
 
-import { ProcessStatus } from '../../models/ProcessStatus'
 import { CloseDrawer } from '../../models/Events'
-import { emit } from 'cluster'
 
 export default class RouterTransitionModule {
 
@@ -18,21 +13,21 @@ export default class RouterTransitionModule {
   }
 
   public static afterTransition(to: Route, from: Route, app: Vue) {
-    switch (to.name) {
-      case 'home':
-      case 'createNewListing':
-      case 'allListings':
-      case 'candidatesListings':
-      case 'listedListings':
-      case 'userAllListings':
-      case 'userCandidates':
-      case 'userListed':
-      case 'supportHome':
-      case 'singleCandidate':
-      case 'singleListed':
-        return app.$root.$emit(CloseDrawer)
-      default:
-        // do nothing
-    }
+    // switch (to.name) {
+    //   case 'home':
+    //   case 'createNewListing':
+    //   case 'allListings':
+    //   case 'candidatesListings':
+    //   case 'listedListings':
+    //   case 'userAllListings':
+    //   case 'userCandidates':
+    //   case 'userListed':
+    //   case 'supportHome':
+    //   case 'singleCandidate':
+    //   case 'singleListed':
+    //     return app.$root.$emit(CloseDrawer)
+    //   default:
+    //     // do nothing
+    // }
   }
 }

--- a/tests/unit/components/ui/RouterTabs.spec.ts
+++ b/tests/unit/components/ui/RouterTabs.spec.ts
@@ -62,6 +62,7 @@ describe('RouterTabs.vue', () => {
     expect(wrapper.vm.$router.currentRoute.fullPath.endsWith('/candidates')).toBeFalsy()
     candidates.trigger('click')
     expect(wrapper.vm.$router.currentRoute.fullPath.endsWith('/candidates')).toBeTruthy()
+    expect(wrapper.emitted('close-drawer'))
 
     expect(wrapper.vm.$router.currentRoute.fullPath.endsWith('/listed')).toBeFalsy()
     listed.trigger('click')


### PR DESCRIPTION
Was getting a bug where I would try to switch from `details` to `listing` tab. The `afterTransition` would emit `CloseDrawer` after the route got switched. `FfaCandidateView` would then run the `onDrawerClosed` callback, which pushes the route to the previous route- so it would switch, then quickly switch back, appearing like the tab wasn't selected. 